### PR TITLE
Get rid of Test::Lab::Experiment::Default.

### DIFF
--- a/lib/Test/Lab.pm6
+++ b/lib/Test/Lab.pm6
@@ -9,7 +9,7 @@ our %context = Hash.new;
 
 #| Change the default Experiment class to instantiate by modifying
 #| this variable.
-our $experiment-class = Test::Lab::Experiment::Default;
+our $experiment-class = Test::Lab::Experiment;
 
 #| Define and run a lab experiment
 #|

--- a/lib/Test/Lab/Default.pm6
+++ b/lib/Test/Lab/Default.pm6
@@ -1,6 +1,0 @@
-class Test::Lab::Experiment { ... }
-
-class Test::Lab::Experiment::Default is Test::Lab::Experiment {
-  method is-enabled { True }
-  method publish($result) { }
-}

--- a/lib/Test/Lab/Experiment.pm6
+++ b/lib/Test/Lab/Experiment.pm6
@@ -1,5 +1,3 @@
-class Test::Lab::Experiment::Default { ... }
-
 #| This role provides shared behavior for experiments.
 #| Includers must implement C<is-enabled> and
 #| C<publish(result)>.
@@ -223,12 +221,7 @@ class Test::Lab::Experiment {
     self.try: &sub, :name('control');
   }
 
-  method is-enabled { !!! }
-
-  method publish($result) { !!! }
-}
-
-class Test::Lab::Experiment::Default is Test::Lab::Experiment {
   method is-enabled { True }
-  method publish($result) { }
+
+  method publish($result) {  }
 }

--- a/t/020-experiment.t
+++ b/t/020-experiment.t
@@ -19,38 +19,12 @@ class Fake is Test::Lab::Experiment {
 
 subtest {
   subtest {
-    my $ex = Test::Lab::Experiment::Default.new(:name<hello>);
-    isa-ok $ex, Test::Lab::Experiment::Default, 'uses builtin defaults';
+    my $ex = Test::Lab::Experiment.new(:name<hello>);
+    isa-ok $ex, Test::Lab::Experiment, 'uses builtin defaults';
     is $ex.name, "hello", "default name properly set";
   }, 'has a default implementation';
 
   is Fake.new.name, "experiment", "properly defaults to 'experiment'";
-
-  subtest {
-    plan 2;
-
-    my class A is Test::Lab::Experiment {
-      method new($name = 'experiment') {
-        Test::Lab::Experiment.bless(:$name)
-      }
-    }
-    my $a = A.new;
-
-    try {
-      CATCH { when X::StubCode { pass "is-enabled is a stub" }
-              default { flunk "Caught the wrong error" } }
-      $a.is-enabled;
-      flunk "No error was thrown"
-    }
-
-    try {
-      CATCH { when X::StubCode { pass "publish is a stub" }
-              default { flunk "Caught the wrong error" } }
-      $a.publish('result');
-      flunk "No error was thrown"
-    }
-
-  }, 'requires includers to implement «is-enabled» and «publish»';
 
   subtest {
     plan 2;
@@ -143,8 +117,8 @@ subtest {
   subtest {
     plan 3;
 
-    my $ex = Test::Lab::Experiment::Default.new(:name<hello>);
-    isa-ok $ex, Test::Lab::Experiment::Default;
+    my $ex = Test::Lab::Experiment.new(:name<hello>);
+    isa-ok $ex, Test::Lab::Experiment;
     my role Boom { method publish($result) { die 'boomtown' } }
     $ex = $ex but Boom;
 

--- a/t/030-default.t
+++ b/t/030-default.t
@@ -5,7 +5,7 @@ use lib 'lib';
 use Test::Lab::Experiment;
 
 sub it($behavior, &block) {
-  my Test::Lab::Experiment::Default $*ex .= new;
+  my Test::Lab::Experiment $*ex .= new;
   subtest &block, $behavior;
 }
 
@@ -18,8 +18,8 @@ it 'noops publish', {
 }
 
 it 'is an experiment', {
-  isa-ok $*ex, Test::Lab::Experiment::Default;
-  isa-ok Test::Lab::Experiment::Default, Test::Lab::Experiment;
+  isa-ok $*ex, Test::Lab::Experiment;
+  isa-ok Test::Lab::Experiment, Test::Lab::Experiment;
 }
 
 it 'rethrows when an internal action throws', {

--- a/t/040-observation.t
+++ b/t/040-observation.t
@@ -5,7 +5,7 @@ use lib 'lib';
 use Test::Lab::Experiment;
 
 sub it($behavior, &block) {
-  my Test::Lab::Experiment::Default $*ex .= new(:name<test>);
+  my Test::Lab::Experiment $*ex .= new(:name<test>);
   subtest &block, $behavior;
 }
 

--- a/t/050-result.t
+++ b/t/050-result.t
@@ -7,7 +7,7 @@ use Test::Lab::Observation;
 use Test::Lab::Result;
 
 sub it($behavior, &block) {
-  my Test::Lab::Experiment::Default $*ex .= new(:name<experiment>);
+  my Test::Lab::Experiment $*ex .= new(:name<experiment>);
   subtest &block, $behavior;
 }
 


### PR DESCRIPTION
We are now using Test::Lab::Experiment both as the base class and the default do nothing implementation.
